### PR TITLE
Add simple event subscription

### DIFF
--- a/lib/page_session.ex
+++ b/lib/page_session.ex
@@ -13,8 +13,13 @@ defmodule ChromeRemoteInterface.PageSession do
     url: "",
     socket: nil,
     callbacks: [],
+    event_subscribers: %{},
     ref_id: 1
   ]
+
+  # ---
+  # Public API
+  # ---
 
   @doc """
   Connect to a Page's 'webSocketDebuggerUrl'.
@@ -32,11 +37,42 @@ defmodule ChromeRemoteInterface.PageSession do
   end
 
   @doc """
+  Subscribe to an event.
+
+  Events that get fired will be returned to the subscribed process under the following format:
+
+  ```
+  {:chrome_remote_interface, event_name, response}
+  ```
+
+  Please note that you must also enable events for that domain!
+
+  Example:
+
+  ```
+  iex> ChromeRemoteInterface.RPC.Page.enable(page_pid)
+  iex> ChromeRemoteInterface.PageSession.subscribe(page_pid, "Page.loadEventFired")
+  iex> ChromeRemoteInterface.RPC.Page.navigate(page_pid, %{url: "https://google.com"})
+  iex> flush()
+  {:chrome_remote_interface, "Page.loadEventFirst", %{"method" => "Page.loadEventFired",
+     "params" => %{"timestamp" => 1012329.888558}}}
+  ```
+  """
+  @spec subscribe(pid(), String.t, pid()) :: any()
+  def subscribe(pid, event, subscriber_pid \\ self()) do
+    GenServer.call(pid, {:subscribe, event, subscriber_pid})
+  end
+
+  @doc """
   Executes a raw JSON RPC command through Websockets.
   """
   def execute_command(pid, method, params) do
     GenServer.call(pid, {:execute_command, method, params})
   end
+
+  # ---
+  # Callbacks
+  # ---
 
   def init(url) do
     {:ok, socket} = ChromeRemoteInterface.Websocket.start_link(url)
@@ -68,12 +104,49 @@ defmodule ChromeRemoteInterface.PageSession do
     {:noreply, new_state}
   end
 
+  # @todo(vy): Subscriber pids that die should be removed from being subscribed
+  def handle_call({:subscribe, event, subscriber_pid}, _from, state) do
+    new_event_subscribers =
+      state
+      |> Map.get(:event_subscribers, %{})
+      |> Map.update(event, [subscriber_pid], fn(subscriber_pids) ->
+        [subscriber_pid | subscriber_pids]
+      end)
+
+    new_state = %{state | event_subscribers: new_event_subscribers}
+
+    {:reply, :ok, new_state}
+  end
+
+  # This handles websocket frames coming from the websocket connection.
+  #
+  # If a frame has an ID:
+  #   - That means it's for an RPC call, so we will reply to the caller with the response.
+  #
+  # If the frame is an event:
+  #   - Forward the event to any subscribers.
   def handle_info({:message, frame_data}, state) do
     json = Poison.decode!(frame_data)
-    error = json["error"]
     id = json["id"]
+    method = json["method"]
 
-    Enum.find(state.callbacks, fn({ref_id, _from}) ->
+    # Message is an RPC response
+    if id do
+      send_rpc_response(state.callbacks, id, json)
+    end
+
+    # Message is an Domain event
+    if method do
+      send_event(state.event_subscribers, method, json)
+    end
+
+    {:noreply, state}
+  end
+
+  defp send_rpc_response(callbacks, id, json) do
+    error = json["error"]
+
+    Enum.find(callbacks, fn({ref_id, _from}) ->
       ref_id == id
     end)
     |> case do
@@ -82,8 +155,17 @@ defmodule ChromeRemoteInterface.PageSession do
         GenServer.reply(from, {status, json})
       _ -> :ok
     end
+  end
 
-    {:noreply, state}
+  defp send_event(event_subscribers, event_name, json) do
+    event = {:chrome_remote_interface, event_name, json}
+
+    pids_subscribed_to_event =
+      event_subscribers
+      |> Map.get(event_name, [])
+
+    pids_subscribed_to_event
+    |> Enum.each(&(send(&1, event)))
   end
 
   def terminate(_reason, state) do

--- a/test/chrome_remote_interface_test.exs
+++ b/test/chrome_remote_interface_test.exs
@@ -1,8 +1,0 @@
-defmodule ChromeRemoteInterfaceTest do
-  use ExUnit.Case
-  doctest ChromeRemoteInterface
-
-  test "greets the world" do
-    assert ChromeRemoteInterface.hello() == :world
-  end
-end

--- a/test/page_session_test.exs
+++ b/test/page_session_test.exs
@@ -1,0 +1,71 @@
+defmodule ChromeRemoteInterface.PageSessionTest do
+  use ExUnit.Case
+
+  alias ChromeRemoteInterface.PageSession
+
+  test "Notifies subscribers of events" do
+    state = %PageSession{}
+
+    {:reply, :ok, state} = PageSession.handle_call(
+     {:subscribe, "TestEvent", self()},
+     self(),
+     state
+    )
+
+    json = Poison.encode!(%{
+      method: "TestEvent"
+    })
+
+    PageSession.handle_info({:message, json}, state)
+
+    assert_receive {:chrome_remote_interface, "TestEvent", _}
+  end
+
+  test "Can unsubscribe from events" do
+    state = %PageSession{}
+
+    {:reply, :ok, state} = PageSession.handle_call(
+     {:subscribe, "TestEvent", self()},
+     self(),
+     state
+    )
+
+    json = Poison.encode!(%{
+      method: "TestEvent"
+    })
+
+    {:reply, :ok, state} = PageSession.handle_call(
+     {:unsubscribe, "TestEvent", self()},
+     self(),
+     state
+   )
+
+    PageSession.handle_info({:message, json}, state)
+
+    refute_receive {:chrome_remote_interface, "TestEvent", _}
+  end
+
+  test "Can unsubscribe from all events" do
+    state = %PageSession{}
+
+    {:reply, :ok, state} = PageSession.handle_call(
+     {:subscribe, "TestEvent", self()},
+     self(),
+     state
+    )
+
+    json = Poison.encode!(%{
+      method: "TestEvent"
+    })
+
+    {:reply, :ok, state} = PageSession.handle_call(
+     {:unsubscribe_all, self()},
+     self(),
+     state
+   )
+
+    PageSession.handle_info({:message, json}, state)
+
+    refute_receive {:chrome_remote_interface, "TestEvent", _}
+  end
+end


### PR DESCRIPTION
This implements the rough API around #1.

- [x] Able to subscribe to events.
- [ ] Able to synchronously receive a single event.
- [x] Able to unsubscribe from events.
- [ ] Handle cases where subscriber process has died

```
  iex> ChromeRemoteInterface.RPC.Page.enable(page_pid)
  iex> ChromeRemoteInterface.PageSession.subscribe(page_pid, "Page.loadEventFired")
  iex> ChromeRemoteInterface.RPC.Page.navigate(page_pid, %{url: "https://google.com"})
  iex> flush()
  {:chrome_remote_interface, "Page.loadEventFirst", %{"method" => "Page.loadEventFired",
     "params" => %{"timestamp" => 1012329.888558}}}
```