### PR TITLE
Add ability to use `async: pid()` to specify consumer

### DIFF
--- a/lib/chrome_remote_interface.ex
+++ b/lib/chrome_remote_interface.ex
@@ -35,29 +35,25 @@ defmodule ChromeRemoteInterface do
         #{arg_doc}
         """
         def unquote(:"#{name}")(page_pid) do
-          page_pid |> PageSession.call(
+          page_pid |> PageSession.execute_command(
             unquote("#{domain["domain"]}.#{name}"),
-            %{}
+            %{},
+            []
           )
         end
         def unquote(:"#{name}")(page_pid, parameters) do
-          page_pid |> PageSession.call(
+          page_pid |> PageSession.execute_command(
             unquote("#{domain["domain"]}.#{name}"),
-            parameters
+            parameters,
+            []
           )
         end
         def unquote(:"#{name}")(page_pid, parameters, opts) when is_list(opts) do
-          if opts[:async] do
-            page_pid |> PageSession.cast(
-              unquote("#{domain["domain"]}.#{name}"),
-              parameters
-            )
-          else
-            page_pid |> PageSession.call(
-              unquote("#{domain["domain"]}.#{name}"),
-              parameters
-            )
-          end
+          page_pid |> PageSession.execute_command(
+            unquote("#{domain["domain"]}.#{name}"),
+            parameters,
+            opts
+          )
         end
       end
     end

--- a/lib/page_session.ex
+++ b/lib/page_session.ex
@@ -72,10 +72,28 @@ defmodule ChromeRemoteInterface.PageSession do
   end
 
   @doc """
-  Unscribes to all events.
+  Unsubcribes to all events.
   """
   def unsubscribe_all(pid, subscriber_pid \\ self()) do
     GenServer.call(pid, {:unsubscribe_all, subscriber_pid})
+  end
+
+  @doc """
+  Executes an RPC command with the given options.
+
+  Options:
+  `:async` -
+    If a boolean, sends the response as a message to the current process.
+    Else, if provided with a PID, it will send the response to that process instead.
+  """
+  def execute_command(pid, method, params, opts) do
+    async = Keyword.get(opts, :async, false)
+
+    case async do
+      false -> call(pid, method, params)
+      true -> cast(pid, method, params, self())
+      from when is_pid(from) -> cast(pid, method, params, from)
+    end
   end
 
   @doc """


### PR DESCRIPTION
Closes https://github.com/andrewvy/chrome-remote-interface/issues/13.

This modifies the RPC option: `async: true` to also accept a pid, so that `async: pid()` will cause the async message reply to be received at the specified pid.

> Example:

`ChromeRemoteInterface.RPC.Page.navigate(page_pid, %{url: "https://youtube.com"}, async: pid)`