### PR TITLE
Fix for session missing init callback, does not need to be GenServer

### DIFF
--- a/lib/session.ex
+++ b/lib/session.ex
@@ -8,8 +8,6 @@ defmodule ChromeRemoteInterface.Session do
     Server
   }
 
-  use GenServer
-
   @default_opts [
     host: "localhost",
     port: 9222


### PR DESCRIPTION
It would appear that the `ChromeRemoteInterface.Session` does not need to be a GenServer.

This will also remove the following warning:
```
warning: function init/1 required by behaviour GenServer is not implemented (in module ChromeRemoteInterface.Session).

We will inject a default implementation for now:

    def init(init_arg) do
      {:ok, init_arg}
    end
```