### PR TITLE
Handle remote closed

### DIFF
--- a/lib/websocket.ex
+++ b/lib/websocket.ex
@@ -11,4 +11,13 @@ defmodule ChromeRemoteInterface.Websocket do
     send(state, {:message, frame_data})
     {:ok, state}
   end
+
+  def handle_disconnect(_status, state) do
+    Process.exit(state, :remote_closed)
+    {:ok, state}
+  end
+
+  def terminate({:remote, :closed}, _state) do
+    :stop
+  end
 end


### PR DESCRIPTION
I found a problem while working with my app. When chrome is opened, and then closed manually, I get a `{:remote, :closed}` termination from WebsockEx. I added a `handle_disconnect` callback to the WebSocket module, and trapped exits in `PageSession` so we could handle the remote closing gracefully, and handle it in the supervising process properly.