### PR TITLE
Use correct HTTP method for new page endpoint

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -6,11 +6,13 @@ defmodule ChromeRemoteInterface.HTTP do
   @type success_http_response :: {:ok, Map.t()}
   @type error_http_response :: {:error, any()}
 
-  @spec call(ChromeRemoteInterface.Server.t(), String.t()) ::
+  @spec call(ChromeRemoteInterface.Server.t(), String.t(), [method: :get | :put]) ::
           success_http_response | error_http_response
-  def call(server, path) do
+  def call(server, path, opts \\ []) do
+    method = Keyword.get(opts, :method, :get)
+
     server
-    |> execute_request(path)
+    |> execute_request(method, path)
     |> handle_response()
   end
 
@@ -22,8 +24,8 @@ defmodule ChromeRemoteInterface.HTTP do
     "http://#{server.host}:#{server.port}#{path}"
   end
 
-  defp execute_request(server, path) do
-    :hackney.request(:get, http_url(server, path), [], <<>>, path_encode_fun: & &1)
+  defp execute_request(server, method, path) when method in [:get, :put] do
+    :hackney.request(method, http_url(server, path), [], <<>>, path_encode_fun: & &1)
   end
 
   defp handle_response({:ok, status_code, _response_headers, client_ref}) do

--- a/lib/session.ex
+++ b/lib/session.ex
@@ -45,7 +45,7 @@ defmodule ChromeRemoteInterface.Session do
   @spec new_page(Server.t()) :: HTTP.success_http_response() | HTTP.error_http_response()
   def new_page(server) do
     server
-    |> HTTP.call("/json/new")
+    |> HTTP.call("/json/new", method: :put)
   end
 
   @doc """


### PR DESCRIPTION
This PR fixes an incompatibility with recent chromium versions (111+)

# Details

The main culprit is the API for creating pages = `PUT /json/new`. This library uses wrong HTTP method `GET` here. This got unnoticed up until now because chromium did not enforce the correct method. However, this changed recently where chromium started enforcing it and responding with an error:

```
Using unsafe HTTP verb GET to invoke /json/new. This action supports only PUT verb.
```

For context, this has been introduced by this chromium PR: https://chromium-review.googlesource.com/c/chromium/src/+/4110715

